### PR TITLE
Remove include key in tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
 
-- include: python.yml
+- import_tasks: python.yml
   when: python_enabled
   tags: [python]

--- a/tasks/python.yml
+++ b/tasks/python.yml
@@ -1,9 +1,9 @@
 ---
 
-- include: install.deb.yml
+- import_tasks: install.deb.yml
   when: ansible_os_family == 'Debian'
 
-- include: install.yum.yml
+- import_tasks: install.yum.yml
   when: ansible_os_family == 'RedHat'
 
 - file: state=directory name=/usr/share/python

--- a/test.yml
+++ b/test.yml
@@ -1,6 +1,6 @@
 - hosts: all
   tasks:
-    - include: tasks/main.yml
+    - import_tasks: tasks/main.yml
   vars_files:
     - defaults/main.yml
     - .travis.yml


### PR DESCRIPTION
fixed below `[DEPRECATION WARNING]` in ansible v2.4.0 or over.

```bash
[DEPRECATION WARNING]: The use of 'include' for tasks has been deprecated. Use 'import_tasks' for static inclusions or 'include_tasks' for dynamic inclusions. This feature
will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: include is kept for backwards compatibility but usage is discouraged. The module documentation details page may explain more about this rationale..
This feature will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stouts/stouts.python/9)
<!-- Reviewable:end -->
