### PR TITLE
fix(ppa): Use ppa:deadsnakes/ppa instead of ppa:fkrull/deadsnakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Ansible role which manage python's versions (pip, virtualenv)
 ---
 
 python_enabled: yes                 # The role is enabled
-python_ppa: ppa:fkrull/deadsnakes   # Python PPA
+python_ppa: ppa:deadsnakes/ppa      # Python PPA
 python_versions: [2.7, 3.4]         # Set versions (2.6, 2.7, 3.3, 3.4) which will be installed
 
 python_install: []                  # Set packages to install globally

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 python_enabled: yes                                 # The role is enabled
-python_ppa: ppa:fkrull/deadsnakes                   # Python PPA
+python_ppa: ppa:deadsnakes/ppa                      # Python PPA
 python_versions: [2.7, 3.4]                         # Set versions (2.6, 2.7, 3.3, 3.4) which will be installed
 
 python_install: []                                  # Set packages to install globally


### PR DESCRIPTION
fixed https://github.com/Stouts/Stouts.python/issues/10

ppa:fkrull/deadsnakes moved new ppa names.
So we need to update `python_ppa` in `defaults/main.yml`

New ppa overview is below.
https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa

Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stouts/stouts.python/11)
<!-- Reviewable:end -->
