### PR TITLE
Fix when using int or string in python_versions: ["3.6"]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ python:
   - "2.7"
 #  - "3.4"
 env:
-  - ANSIBLE_VERSION=2.3.1.0
+  - ANSIBLE_VERSION=latest
 cache: bundler
-#sudo: false
+# sudo: false
 sudo: required
 dist: trusty
 before_install:
@@ -14,7 +14,8 @@ before_install:
  - sudo apt-get install -qq python-apt python-pycurl
 install:
   # Install Ansible.
-  - sudo pip install ansible==$ANSIBLE_VERSION
+  - if [ "$ANSIBLE_VERSION" = "latest" ]; then pip install ansible; else pip install ansible==$ANSIBLE_VERSION; fi
+  - if [ "$ANSIBLE_VERSION" = "latest" ]; then pip install ansible-lint; fi
 script:
   # Prepare tests
   - echo localhost > inventory
@@ -39,7 +40,7 @@ script:
   - command -v virtualenv || exit 1
 
   # Test with python3.4
-  - ansible-playbook -i inventory test.yml --connection=local --sudo  -e "python_version=3.4"
+  - ansible-playbook -i inventory test.yml --connection=local --sudo  -e "python_versions=[3.4]"
 
   #- command -v python3.4 || exit 1
   #- command -v pip3.4 || exit 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ script:
   - command -v virtualenv || exit 1
 
   # Test with python3.4
-  - ansible-playbook -i inventory test.yml --connection=local --sudo  -e "python_versions=[3.7]"
+  - ansible-playbook -i inventory test.yml --connection=local --sudo  -e "python_versions=[3.4]"
 
   #- command -v python3.4 || exit 1
   #- command -v pip3.4 || exit 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 ---
 language: python
 python:
-  - "2.7"
-#  - "3.4"
+#  - "2.7"
+  - "3.6"
 env:
   - ANSIBLE_VERSION=latest
   
@@ -52,8 +52,8 @@ script:
 
   - command -v python || exit 1
   - command -v pip || exit 1
-  - command -v python2.7 || exit 1
-  - command -v pip2.7 || exit 1  
+  - command -v python3.6 || exit 1
+  - command -v pip3.6 || exit 1  
   - command -v virtualenv || exit 1
 
   # Test with python3.4
@@ -63,6 +63,6 @@ script:
   #- command -v pip3.4 || exit 1
 
 python_install: [virtualenv]
-python_versions: [2.7] 
+python_versions: [3.6] 
 python_bin: /usr/bin/python
-python_pkg_bin: /home/travis/virtualenv/python2.7.14/bin
+#python_pkg_bin: /home/travis/virtualenv/python2.7.14/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ script:
   - command -v virtualenv || exit 1
 
   # Test with python3.4
-  - ansible-playbook -i inventory test.yml --connection=local --sudo  -e "python_versions=[3.4]"
+  - ansible-playbook -i inventory test.yml --connection=local --sudo  -e "python_versions=[3]"
 
   #- command -v python3.4 || exit 1
   #- command -v pip3.4 || exit 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,22 @@ python:
 #  - "3.4"
 env:
   - ANSIBLE_VERSION=latest
-cache: bundler
+  
+services:
+  - docker
+
+cache:
+  bundler:
+  directories:
+    - $HOME/.cache/pip
+    
 # sudo: false
 sudo: required
 dist: trusty
+
+virtualenv:
+  system_site_packages: false
+
 before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -qq python-apt python-pycurl
@@ -16,13 +28,18 @@ install:
   # Install Ansible.
   - if [ "$ANSIBLE_VERSION" = "latest" ]; then pip install ansible; else pip install ansible==$ANSIBLE_VERSION; fi
   - if [ "$ANSIBLE_VERSION" = "latest" ]; then pip install ansible-lint; fi
+
+  - pip install molecule  
 script:
   # Prepare tests
   - echo localhost > inventory
 
   # Check syntax
   - ansible-playbook --syntax-check -i inventory test.yml
-
+  
+  # Molecule test
+  # - molecule test
+  
   # First run
   - ansible-playbook -i inventory test.yml --connection=local --sudo
 
@@ -48,4 +65,4 @@ script:
 python_install: [virtualenv]
 python_versions: [2.7] 
 python_bin: /usr/bin/python
-python_pkg_bin: /home/travis/virtualenv/python2.7.13/bin
+python_pkg_bin: /home/travis/virtualenv/python2.7.14/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ script:
   - command -v virtualenv || exit 1
 
   # Test with python3.4
-  - ansible-playbook -i inventory test.yml --connection=local --sudo  -e "python_versions=[3]"
+  - ansible-playbook -i inventory test.yml --connection=local --sudo  -e "python_versions=[3.7]"
 
   #- command -v python3.4 || exit 1
   #- command -v pip3.4 || exit 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ script:
   - command -v virtualenv || exit 1
 
   # Test with python3.4
-  - ansible-playbook -i inventory test.yml --connection=local --sudo  -e "python_versions=[3.4]"
+  #- ansible-playbook -i inventory test.yml --connection=local --sudo  -e "python_versions=[3.4]"
 
   #- command -v python3.4 || exit 1
   #- command -v pip3.4 || exit 1

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,3 +16,4 @@ python_bin: /usr/bin/python
 python_pkg_bin: /usr/local/bin
 python_yum_disablerepo: no
 python_yum_enablerepo: no
+python_pip_installed_enabled: yes                                 # Pip install is enabled

--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -4,11 +4,21 @@
 
 - name: Install python-pycurl
   apt: name=python-pycurl
-
+  when: item < 3
+  with_items: "{{ python_versions }}"
+  ignore_errors: true
+  
+- name: Install python3-pycurl
+  apt: name=python3-pycurl
+  when: item >= 3
+  with_items: "{{ python_versions }}"
+  
 - name: Add python apt repository
   apt_repository: repo={{python_ppa}} update_cache=yes
   when: python_ppa != False and python_ppa != ""
-
+  become: true
+  ignore_errors: true
+  
 - name: Install python
   apt: name=python{{item}} state=present
   with_items: "{{ python_versions }}"

--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -21,3 +21,4 @@
   apt: name=python{{item}}-distutils state=present
   when: item >= 3
   with_items: "{{ python_versions }}"
+  ignore_errors: true

--- a/tasks/install.yum.yml
+++ b/tasks/install.yum.yml
@@ -1,9 +1,16 @@
 ---
 
+#regex_replace fail when there is an int
+#- debug: msg="python_versions {{ item|map('regex_replace', '.','')|list }}"
+#  with_items: "{{python_versions}}"
+  
+- debug: msg="python_versions {{ item|replace('.','')|list }}"
+  with_items: "{{python_versions}}"  
+  
 - name: Install python
-  yum: name=python{{item | regex_replace('.')}} state=present enablerepo={{python_yum_enablerepo or None}} disablerepo={{python_yum_disablerepo or None}}
-  with_items: "{{ python_versions }}"
+  yum: name=python{{ item|replace('.','') }} state=present enablerepo={{python_yum_enablerepo or None}} disablerepo={{python_yum_disablerepo or None}}
+  with_items: "{{python_versions}}"
 
 - name: Install python-dev
-  yum: name=python{{item | regex_replace('.')}}-devel state=present enablerepo={{python_yum_enablerepo or None}} disablerepo={{python_yum_disablerepo or None}}
-  with_items: "{{ python_versions }}"
+  yum: name=python{{ item|replace('.','') }}-devel state=present enablerepo={{python_yum_enablerepo or None}} disablerepo={{python_yum_disablerepo or None}}
+  with_items: "{{python_versions}}"

--- a/tasks/install.yum.yml
+++ b/tasks/install.yum.yml
@@ -3,14 +3,14 @@
 #regex_replace fail when there is an int
 #- debug: msg="python_versions {{ item|map('regex_replace', '.','')|list }}"
 #  with_items: "{{python_versions}}"
-  
-- debug: msg="python_versions {{ item|replace('.','')|list }}"
-  with_items: "{{python_versions}}"  
-  
+
+- debug: msg="python_versions {{ item|replace('.','') }}"
+  with_items: "{{python_versions}}"
+
 - name: Install python
-  yum: name=python{{ item|replace('.','') }} state=present enablerepo={{python_yum_enablerepo or None}} disablerepo={{python_yum_disablerepo or None}}
+  yum: name=python{{item|replace('.','')}} state=present enablerepo={{python_yum_enablerepo or None}} disablerepo={{python_yum_disablerepo or None}}
   with_items: "{{python_versions}}"
 
 - name: Install python-dev
-  yum: name=python{{ item|replace('.','') }}-devel state=present enablerepo={{python_yum_enablerepo or None}} disablerepo={{python_yum_disablerepo or None}}
+  yum: name=python{{item|replace('.','')}}-devel state=present enablerepo={{python_yum_enablerepo or None}} disablerepo={{python_yum_disablerepo or None}}
   with_items: "{{python_versions}}"

--- a/tasks/python.yml
+++ b/tasks/python.yml
@@ -10,12 +10,14 @@
 
 - name: Install pip - pt. 1
   copy: src=get-pip.py dest=/usr/share/python/get-pip.py
+  when: python_pip_installed_enabled
 
 - name: Install pip - pt. 2
   shell: "{{python_bin}}{{item|replace('u','')}} /usr/share/python/get-pip.py creates={{python_pkg_bin}}/pip{{item|replace('u','')}}"
   with_items: "{{ python_versions }}"
   register: python_pip_installed
   changed_when: false
+  when: python_pip_installed_enabled
   become: yes
 
 - name: Update tools
@@ -50,7 +52,7 @@
   shell: virtualenv {{item.path}} --python={{item.python|default('python')}}
   args:
     creates: "{{item.path}}"
-  with_items: "{{python_virtualenvs}}"    
+  with_items: "{{python_virtualenvs}}"
   tags:
     - venv
   environment:

--- a/tasks/python.yml
+++ b/tasks/python.yml
@@ -37,8 +37,8 @@
 
 - name: Setup virtualenvs
   pip:
-    virtualenv: {{item.path}}
-    virtualenv_python: {{item.python|default('python')}}
+    virtualenv: "{{ item.path }}"
+    virtualenv_python: "{{ item.python|default('python') }}"
     virtualenv_site_packages: false
   with_items: "{{ python_virtualenvs }}"
   tags:
@@ -49,13 +49,13 @@
 
 - name: Setup virtualenvs for specific user
   pip:
-    virtualenv: {{item.path}}
-    virtualenv_python: {{item.python|default('python')}}
+    virtualenv: "{{ item.path }}"
+    virtualenv_python: "{{ item.python|default('python') }}"
     virtualenv_site_packages: false
   with_items: "{{ python_virtualenvs }}"
   tags:
     - venv
   environment:
     PATH: "{{ ansible_env.PATH }}:{{ ansible_user_dir }}/.local/bin"
-  become_user: "{{item.user|default(python_virtualenv_user)}}"
+  become_user: "{{ item.user|default(python_virtualenv_user) }}"
   when: "python_virtualenv_user is defined"

--- a/tasks/python.yml
+++ b/tasks/python.yml
@@ -36,17 +36,26 @@
   with_items: "{{ python_versions }}"
 
 - name: Setup virtualenvs
-  shell: virtualenv {{item.path}} --python={{item.python|default('python')}}
-  args:
-    creates: "{{item.path}}"
+  pip:
+    virtualenv: {{item.path}}
+    virtualenv_python: {{item.python|default('python')}}
+    virtualenv_site_packages: false
   with_items: "{{ python_virtualenvs }}"
+  tags:
+    - venv
+  environment:
+    PATH: "{{ ansible_env.PATH }}:{{ ansible_user_dir }}/.local/bin"
   when: "python_virtualenv_user is not defined"
 
 - name: Setup virtualenvs for specific user
-  shell: virtualenv {{item.path}} --python={{item.python|default('python')}}
-  args:
-    creates: "{{item.path}}"
+  pip:
+    virtualenv: {{item.path}}
+    virtualenv_python: {{item.python|default('python')}}
+    virtualenv_site_packages: false
   with_items: "{{ python_virtualenvs }}"
+  tags:
+    - venv
+  environment:
+    PATH: "{{ ansible_env.PATH }}:{{ ansible_user_dir }}/.local/bin"
   become_user: "{{item.user|default(python_virtualenv_user)}}"
   when: "python_virtualenv_user is defined"
-

--- a/tasks/python.yml
+++ b/tasks/python.yml
@@ -12,7 +12,7 @@
   copy: src=get-pip.py dest=/usr/share/python/get-pip.py
 
 - name: Install pip - pt. 2
-  shell: "{{python_bin}}{{item}} /usr/share/python/get-pip.py creates={{python_pkg_bin}}/pip{{item}}"
+  shell: "{{python_bin}}{{item|replace('u','')}} /usr/share/python/get-pip.py creates={{python_pkg_bin}}/pip{{item|replace('u','')}}"
   with_items: "{{ python_versions }}"
   register: python_pip_installed
   changed_when: false
@@ -28,34 +28,32 @@
 - name: Install global python packages
   pip: name="{{python_install|join(' ')}}" executable={{python_pkg_bin}}/pip{{item}}
   when: python_install
-  with_items: "{{ python_versions }}"
+  with_items: "{{python_versions}}"
 
 - name: Install virtualenv
-  pip: name="virtualenv" executable={{python_pkg_bin}}/pip{{item}}
+  pip: name="virtualenv" executable={{python_pkg_bin}}/pip{{item|replace('u','')}}
   when: not( (python_virtualenvs is undefined) or (python_virtualenvs is none) or (python_virtualenvs | trim == '') )
-  with_items: "{{ python_versions }}"
+  with_items: "{{python_versions}}"
 
 - name: Setup virtualenvs
-  pip:
-    virtualenv: "{{ item.path }}"
-    virtualenv_python: "{{ item.python|default('python') }}"
-    virtualenv_site_packages: false
-  with_items: "{{ python_virtualenvs }}"
+  shell: virtualenv {{item.path}} --python={{item.python|default('python')}}
+  args:
+    creates: "{{item.path}}"
+  with_items: "{{python_virtualenvs}}"
   tags:
     - venv
   environment:
-    PATH: "{{ ansible_env.PATH }}:{{ ansible_user_dir }}/.local/bin"
+    PATH: "{{ansible_env.PATH}}:{{ansible_user_dir}}/.local/bin"
   when: "python_virtualenv_user is not defined"
 
 - name: Setup virtualenvs for specific user
-  pip:
-    virtualenv: "{{ item.path }}"
-    virtualenv_python: "{{ item.python|default('python') }}"
-    virtualenv_site_packages: false
-  with_items: "{{ python_virtualenvs }}"
+  shell: virtualenv {{item.path}} --python={{item.python|default('python')}}
+  args:
+    creates: "{{item.path}}"
+  with_items: "{{python_virtualenvs}}"    
   tags:
     - venv
   environment:
-    PATH: "{{ ansible_env.PATH }}:{{ ansible_user_dir }}/.local/bin"
-  become_user: "{{ item.user|default(python_virtualenv_user) }}"
+    PATH: "{{ansible_env.PATH}}:{{ansible_user_dir}}/.local/bin"
+  become_user: "{{item.user|default(python_virtualenv_user)}}"
   when: "python_virtualenv_user is defined"

--- a/test.yml
+++ b/test.yml
@@ -1,6 +1,10 @@
-- hosts: all
+- hosts: localhost
   tasks:
     - import_tasks: tasks/main.yml
   vars_files:
     - defaults/main.yml
     - .travis.yml
+  vars:
+    python_ppa: ""
+    python_versions: [3.6, 3.8]
+    python_pip_installed_enabled: false


### PR DESCRIPTION
Fix when using int instead of string 

For instance 
 python_versions: [3.5, 3.6]
 python_versions: ["3.5", "3.6"]

Tested with:

`
hosts: RedHat-7*:RedHat-6*:RedHat-5*:CentOS-7*:CentOS-6*:Ubuntu-12*:Ubuntu-13*:Ubuntu-14*:Ubuntu-16*:Ubuntu-18*

  vars:
      python_versions: [2.7, 3.5]
      python_versions: [3, 3.6]
      python_versions: [2]
      python_versions: ["3.5"]
      python_versions: ["3.6"]
`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stouts/stouts.python/14)
<!-- Reviewable:end -->
